### PR TITLE
chore(compiling): don't append to $OPUS_LIB_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn link_opus(is_static: bool, opus_build_dir: impl Display) {
     );
 
     println!("cargo:rustc-link-lib={}=opus", is_static_text);
-    if is_static {
+    if is_static && find_installed_opus().is_none() {
         println!("cargo:rustc-link-search=native={}", opus_build_dir);
     } else {
         println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn link_opus(is_static: bool, opus_build_dir: impl Display) {
         is_static_text, opus_build_dir
     );
     println!("cargo:rustc-link-lib={}=opus", is_static_text);
-    println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);
+    println!("cargo:rustc-link-search=native={}", opus_build_dir);
 }
 
 #[cfg(any(unix, target_env = "gnu"))]

--- a/build.rs
+++ b/build.rs
@@ -53,18 +53,17 @@ fn build_opus(is_static: bool) {
 
 fn link_opus(is_static: bool, opus_build_dir: impl Display) {
     let is_static_text = rustc_linking_word(is_static);
-    let opus_build_dir = if !is_static {
-        format!("{}/lib", opus_build_dir)
-    } else {
-        format!("{}", opus_build_dir)
-    };
-
     println!(
         "cargo:info=Linking Opus as {} lib: {}",
         is_static_text, opus_build_dir
     );
+
     println!("cargo:rustc-link-lib={}=opus", is_static_text);
-    println!("cargo:rustc-link-search=native={}", opus_build_dir);
+    if is_static {
+        println!("cargo:rustc-link-search=native={}", opus_build_dir);
+    } else {
+        println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);
+    }
 }
 
 #[cfg(any(unix, target_env = "gnu"))]

--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,11 @@ fn build_opus(is_static: bool) {
 
 fn link_opus(is_static: bool, opus_build_dir: impl Display) {
     let is_static_text = rustc_linking_word(is_static);
+    let opus_build_dir = if !is_static {
+        format!("{}/lib", opus_build_dir)
+    } else {
+        format!("{}", opus_build_dir)
+    };
 
     println!(
         "cargo:info=Linking Opus as {} lib: {}",

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn link_opus(is_static: bool, opus_build_dir: impl Display) {
     );
 
     println!("cargo:rustc-link-lib={}=opus", is_static_text);
-    if is_static && find_installed_opus().is_none() {
+    if is_static && find_installed_opus().is_some() {
         println!("cargo:rustc-link-search=native={}", opus_build_dir);
     } else {
         println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);


### PR DESCRIPTION
I found the need to cross compile opus and use environment variables to point to the `.a` file. I feel that it would be better if the `build.rs` script didn't append anything to `$OPUS_LIB_DIR`. 