### PR TITLE
Allow pkg-config on non unixy-gnu platforms

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,7 +62,6 @@ fn link_opus(is_static: bool, opus_build_dir: impl Display) {
     println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);
 }
 
-#[cfg(any(unix, target_env = "gnu"))]
 fn find_via_pkg_config(is_static: bool) -> bool {
     pkg_config::Config::new()
         .statik(is_static)
@@ -128,7 +127,6 @@ fn main() {
 
     let is_static = is_static_build();
 
-    #[cfg(any(unix, target_env = "gnu"))]
     {
         if std::env::var("LIBOPUS_NO_PKG").is_ok() || std::env::var("OPUS_NO_PKG").is_ok() {
             println!("cargo:info=Bypassed `pkg-config`.");


### PR DESCRIPTION
I wanted to cross compile this package while using pkg-config, but found that pkg-config is gated behind unixy-gnu host platforms. I don't really see why this is necessary since not having pkg-config should just fail normally. For reference, I have a Windows host and am using pkg-config from msys2. 

As a result, I have disabled this cfg flag. I don't believe this is breaking. 