### PR TITLE
fix: configure cmake for 4.0

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,7 +47,9 @@ fn build_opus(is_static: bool) {
     );
 
     println!("cargo:info=Building Opus via CMake.");
-    let opus_build_dir = cmake::build(opus_path);
+    let opus_build_dir = cmake::Config::new(opus_path)
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+        .build();
     link_opus(is_static, opus_build_dir.display())
 }
 


### PR DESCRIPTION
This pr adds CMAKE_POLICY_VERSION_MINIMUM=3.5 when building, so that this project can be built using CMake 4.0. Closes #21 .

Actually I don't expect this PR to be merged, so here's the patch code for Cargo.toml so that you can compile serenity or something else:
```toml

[patch.crates-io]
audiopus_sys = { git = 'https://github.com/sevenc-nanashi/audiopus_sys', rev = '00e9d16' }

```